### PR TITLE
Update docs for service principal

### DIFF
--- a/baseline-testing/README.md
+++ b/baseline-testing/README.md
@@ -7,7 +7,7 @@ This folder contains all baseline system tests for the TSLA AI UI Agent project.
 Before running the tests, ensure you have:
 
 1. **Node.js** installed and in your PATH
-2. **Azure CLI** installed and authenticated (`az login`)
+2. **Azure CLI** installed and authenticated (`az login`) **or** service principal environment variables set (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`)
 3. **Development server** running for API tests (`npm run dev`)
 
 ## Test Scripts

--- a/infrastructure.md
+++ b/infrastructure.md
@@ -727,6 +727,7 @@ Use a service principal when managed identity or `az login` are not available.
    - `AZURE_TENANT_ID` = `tenant`
    - `AZURE_CLIENT_SECRET` = `password`
 3. `DefaultAzureCredential` will automatically use these values when present.
+4. Verify the credentials by running `./baseline-testing/quick-auth-test.sh`.
 
 ### For GitHub Actions (Required for Automated Deployment - OIDC Authentication)
 

--- a/project-management.mdc
+++ b/project-management.mdc
@@ -236,9 +236,10 @@
 **Status**: Not Started | **Target**: Prepare for feature development
 
 ### 2.1 Service Principal Setup (Online Compiler)
-- [ ] Create service principal with `az ad sp create-for-rbac`
-- [ ] Add `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` variables to Codex
-- [ ] **Configure `AZURE_CLIENT_SECRET` in Codex**
+- [x] Create service principal with `az ad sp create-for-rbac`
+- [x] Add `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` variables to Codex
+- [x] **Configure `AZURE_CLIENT_SECRET` in Codex**
+  - Verified credentials using `./baseline-testing/quick-auth-test.sh`
 
 ### 2.2 Project Structure Enhancement
 - [x] Implement folder structure from PRD


### PR DESCRIPTION
## Summary
- mark service principal setup complete in project management doc
- add quick-auth test verification step to infrastructure guide
- clarify baseline test prerequisites for service principal environments

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68476f1293848333b7f004851e923002