### PR TITLE
Implement basic agent flow UI

### DIFF
--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -1,0 +1,12 @@
+import AgentFlow from '@/features/ai/components/AgentFlow';
+import { AgentFlowProvider } from '@/providers/AgentFlowProvider';
+
+export default function AgentPage() {
+  return (
+    <AgentFlowProvider>
+      <div className="container mx-auto p-6">
+        <AgentFlow />
+      </div>
+    </AgentFlowProvider>
+  );
+}

--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -4,9 +4,7 @@ import { AgentFlowProvider } from '@/providers/AgentFlowProvider';
 export default function AgentPage() {
   return (
     <AgentFlowProvider>
-      <div className="container mx-auto p-6">
-        <AgentFlow />
-      </div>
+      <AgentFlow />
     </AgentFlowProvider>
   );
 }

--- a/docs/ai-agent/prd.md
+++ b/docs/ai-agent/prd.md
@@ -258,3 +258,17 @@ npx create-next-app@latest
 * Which graph library will be selected (leave flexible for now)
 * How to handle authentication/token rotation for blob SAS
 * Cost optimization for blob cleanup policies
+
+---
+
+### Test-Driven Development & Validation Approach:
+
+* The project will follow a **test-driven development (TDD)** methodology.
+* Emphasis is on **integration testing** and **end-to-end validation** of actual functionality, rather than isolated unit tests.
+* Tests should validate real user flows, agent pipeline execution, and integration with external services (e.g., Azure AI Foundry, Azure Blob Storage).
+* Automated tests should cover:
+  * Full agent pipeline execution (from creative brief to artifact download)
+  * Visual execution tracking and UI state transitions
+  * API and storage integration (mocked or real, as appropriate)
+  * Accessibility and usability of generated UIs
+* Unit testing is **not required** unless it directly supports integration or functional validation.

--- a/features/ai/components/AgentFlow.tsx
+++ b/features/ai/components/AgentFlow.tsx
@@ -1,3 +1,70 @@
+'use client';
+import { useState } from 'react';
+import { useAgentFlow } from '@/providers/AgentFlowProvider';
+
 export default function AgentFlow() {
-  return <div>Agent flow placeholder</div>;
+  const { steps, currentStep, completed, completeStep, abort, aborted } = useAgentFlow();
+  const [brief, setBrief] = useState('');
+
+  const startFlow = () => {
+    if (currentStep === 0) {
+      completeStep(0);
+    }
+  };
+
+  const nextStep = () => {
+    if (currentStep < steps.length) {
+      completeStep(currentStep);
+    }
+  };
+
+  const handleAbort = () => abort();
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">AI Agent Flow</h1>
+
+      {currentStep === 0 && !aborted && (
+        <div className="space-y-3">
+          <label className="block font-medium">Creative Brief</label>
+          <textarea
+            className="w-full p-2 border rounded"
+            rows={4}
+            value={brief}
+            onChange={(e) => setBrief(e.target.value)}
+          />
+          <button onClick={startFlow} className="px-4 py-2 bg-blue-600 text-white rounded">
+            Start
+          </button>
+        </div>
+      )}
+
+      <ol className="space-y-2">
+        {steps.map((step, index) => (
+          <li
+            key={step}
+            className={`p-2 rounded border ${currentStep === index && !aborted ? 'bg-blue-100' : completed.has(index) ? 'bg-green-100' : 'bg-gray-50'}`}
+          >
+            {step}
+          </li>
+        ))}
+      </ol>
+
+      {!aborted && currentStep > 0 && currentStep < steps.length && (
+        <div className="flex gap-4">
+          <button onClick={nextStep} className="px-4 py-2 bg-blue-600 text-white rounded">
+            Next Step
+          </button>
+          <button onClick={handleAbort} className="px-4 py-2 bg-red-600 text-white rounded">
+            Abort
+          </button>
+        </div>
+      )}
+
+      {aborted && <p className="text-red-600 font-medium">Flow aborted</p>}
+      {!aborted && currentStep >= steps.length && (
+        <p className="text-green-700 font-medium">Agent flow complete</p>
+      )}
+    </div>
+  );
 }

--- a/features/ai/components/AgentFlow.tsx
+++ b/features/ai/components/AgentFlow.tsx
@@ -20,51 +20,178 @@ export default function AgentFlow() {
 
   const handleAbort = () => abort();
 
+  const getStepIcon = (index: number) => {
+    if (completed.has(index)) {
+      return (
+        <div className="w-8 h-8 bg-emerald-500 rounded-full flex items-center justify-center text-white text-sm font-semibold">
+          ✓
+        </div>
+      );
+    }
+    if (currentStep === index && !aborted) {
+      return (
+        <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white text-sm font-semibold animate-pulse">
+          {index + 1}
+        </div>
+      );
+    }
+    return (
+      <div className="w-8 h-8 bg-gray-300 rounded-full flex items-center justify-center text-gray-600 text-sm font-semibold">
+        {index + 1}
+      </div>
+    );
+  };
+
+  const getConnectorLine = (index: number) => {
+    if (index === steps.length - 1) return null;
+    
+    const isCompleted = completed.has(index);
+    const isActive = currentStep > index;
+    
+    return (
+      <div className={`w-0.5 h-12 ml-4 ${isCompleted || isActive ? 'bg-emerald-500' : 'bg-gray-300'} transition-colors duration-300`} />
+    );
+  };
+
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">AI Agent Flow</h1>
-
-      {currentStep === 0 && !aborted && (
-        <div className="space-y-3">
-          <label className="block font-medium">Creative Brief</label>
-          <textarea
-            className="w-full p-2 border rounded"
-            rows={4}
-            value={brief}
-            onChange={(e) => setBrief(e.target.value)}
-          />
-          <button onClick={startFlow} className="px-4 py-2 bg-blue-600 text-white rounded">
-            Start
-          </button>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 p-6">
+      <div className="max-w-4xl mx-auto">
+        {/* Header Section */}
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-blue-600 to-purple-600 rounded-2xl mb-4">
+            <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+          </div>
+          <h1 className="text-4xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent mb-2">
+            AI Agent Flow
+          </h1>
+          <p className="text-gray-600 text-lg">Transform your ideas into beautiful, functional UI components</p>
         </div>
-      )}
 
-      <ol className="space-y-2">
-        {steps.map((step, index) => (
-          <li
-            key={step}
-            className={`p-2 rounded border ${currentStep === index && !aborted ? 'bg-blue-100' : completed.has(index) ? 'bg-green-100' : 'bg-gray-50'}`}
-          >
-            {step}
-          </li>
-        ))}
-      </ol>
+        {/* Creative Brief Section */}
+        {currentStep === 0 && !aborted && (
+          <div className="bg-white rounded-2xl shadow-lg border border-gray-100 p-8 mb-8">
+            <div className="max-w-2xl mx-auto">
+              <h2 className="text-2xl font-semibold text-gray-900 mb-2">Start Your Journey</h2>
+              <p className="text-gray-600 mb-6">Describe your vision and let AI bring it to life</p>
+              
+              <div className="space-y-4">
+                <label className="block">
+                  <span className="text-sm font-medium text-gray-700 mb-2 block">Creative Brief</span>
+                  <textarea
+                    className="w-full p-4 border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 resize-none bg-gray-50 focus:bg-white"
+                    rows={5}
+                    value={brief}
+                    onChange={(e) => setBrief(e.target.value)}
+                    placeholder="Describe the UI component you want to create. Be specific about functionality, style, and data visualization needs..."
+                  />
+                </label>
+                
+                <button 
+                  onClick={startFlow} 
+                  disabled={!brief.trim()}
+                  className="w-full bg-gradient-to-r from-blue-600 to-purple-600 text-white py-4 px-6 rounded-xl font-semibold text-lg shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none disabled:shadow-lg"
+                >
+                  {brief.trim() ? '🚀 Start AI Agent Flow' : 'Enter your creative brief to begin'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
-      {!aborted && currentStep > 0 && currentStep < steps.length && (
-        <div className="flex gap-4">
-          <button onClick={nextStep} className="px-4 py-2 bg-blue-600 text-white rounded">
-            Next Step
-          </button>
-          <button onClick={handleAbort} className="px-4 py-2 bg-red-600 text-white rounded">
-            Abort
-          </button>
+        {/* Progress Steps */}
+        <div className="bg-white rounded-2xl shadow-lg border border-gray-100 p-8 mb-8">
+          <h2 className="text-xl font-semibold text-gray-900 mb-6">Progress Timeline</h2>
+          
+          <div className="space-y-0">
+            {steps.map((step, index) => (
+              <div key={step} className="flex items-start">
+                <div className="flex flex-col items-center">
+                  {getStepIcon(index)}
+                  {getConnectorLine(index)}
+                </div>
+                
+                <div className="ml-4 pb-12 flex-1">
+                  <div className={`p-4 rounded-xl border transition-all duration-300 ${
+                    currentStep === index && !aborted 
+                      ? 'bg-blue-50 border-blue-200 shadow-md' 
+                      : completed.has(index) 
+                        ? 'bg-emerald-50 border-emerald-200' 
+                        : 'bg-gray-50 border-gray-200'
+                  }`}>
+                    <h3 className={`font-semibold mb-1 ${
+                      currentStep === index && !aborted 
+                        ? 'text-blue-900' 
+                        : completed.has(index) 
+                          ? 'text-emerald-900' 
+                          : 'text-gray-700'
+                    }`}>
+                      {step}
+                    </h3>
+                    <p className={`text-sm ${
+                      currentStep === index && !aborted 
+                        ? 'text-blue-700' 
+                        : completed.has(index) 
+                          ? 'text-emerald-700' 
+                          : 'text-gray-500'
+                    }`}>
+                      {currentStep === index && !aborted && 'Currently processing...'}
+                      {completed.has(index) && 'Completed successfully'}
+                      {currentStep < index && 'Waiting...'}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
-      )}
 
-      {aborted && <p className="text-red-600 font-medium">Flow aborted</p>}
-      {!aborted && currentStep >= steps.length && (
-        <p className="text-green-700 font-medium">Agent flow complete</p>
-      )}
+        {/* Action Buttons */}
+        {!aborted && currentStep > 0 && currentStep < steps.length && (
+          <div className="bg-white rounded-2xl shadow-lg border border-gray-100 p-8 mb-8">
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <button 
+                onClick={nextStep} 
+                className="bg-gradient-to-r from-blue-600 to-purple-600 text-white py-3 px-8 rounded-xl font-semibold shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-200"
+              >
+                Continue to Next Step
+              </button>
+              <button 
+                onClick={handleAbort} 
+                className="bg-gradient-to-r from-red-500 to-pink-500 text-white py-3 px-8 rounded-xl font-semibold shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-200"
+              >
+                Abort Flow
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Status Messages */}
+        {aborted && (
+          <div className="bg-red-50 border border-red-200 rounded-2xl p-8 text-center">
+            <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </div>
+            <h3 className="text-xl font-semibold text-red-900 mb-2">Flow Aborted</h3>
+            <p className="text-red-700">The AI agent flow has been stopped. You can start a new flow anytime.</p>
+          </div>
+        )}
+
+        {!aborted && currentStep >= steps.length && (
+          <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-8 text-center">
+            <div className="w-16 h-16 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg className="w-8 h-8 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <h3 className="text-xl font-semibold text-emerald-900 mb-2">Flow Complete!</h3>
+            <p className="text-emerald-700">Your AI agent flow has completed successfully. Your artifacts are ready for download.</p>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/project-management.mdc
+++ b/project-management.mdc
@@ -291,70 +291,91 @@
   - [x] Basic client-side state management for the agent flow (e.g., React Context or Zustand/Jotai).
 
 - **3.1.2 User Identity Management (Client-Side GUID)**
-  - [ ] Generate a unique GUID on the client-side for the user (if one doesn't exist in local storage).
+  - [ ] **Define integration/functional tests for user GUID management** (e.g., test GUID generation, persistence, display, and API usage)
+  - [ ] Implement logic to generate a unique GUID on the client-side for the user (if one doesn't exist in local storage).
   - [ ] Store the User GUID in local storage to persist across sessions.
   - [ ] Display the User GUID in the UI (e.g., in a settings or profile area).
   - [ ] Ensure User GUID is available to be sent with API requests for backend processing (e.g., blob storage paths).
+  - [ ] **Validate by running the defined tests and confirming all pass**
 
 - **3.1.3 Execution Tracking & Display (Client-Side MVP)**
-  - [ ] Basic client-side state to track current execution ID (can be a timestamp or simple counter per session initially).
+  - [ ] **Define integration/functional tests for execution tracking and timeline UI** (e.g., test execution ID tracking, timeline rendering, event logging)
+  - [ ] Implement basic client-side state to track current execution ID (can be a timestamp or simple counter per session initially).
   - [ ] Implement a collapsible timeline UI component.
     - Display start/end timestamps for major agent stages (e.g., Design, Figma, Code).
     - Log key events or decisions in the timeline.
   - [ ] Store a simple execution trace log (JSON object) in client-side state during the agent run.
+  - [ ] **Validate by running the defined tests and confirming all pass**
 
 - **3.1.4 Download Artifacts (Initial Setup)**
+  - [ ] **Define integration/functional tests for artifact download** (e.g., test ZIP packaging, download trigger, file contents)
   - [ ] UI button to trigger download.
   - [ ] Placeholder function for packaging artifacts into a ZIP file (actual zipping and blob retrieval will be in 3.2.8).
+  - [ ] **Validate by running the defined tests and confirming all pass**
 
 ### 3.2 AI Integration & Core Logic (MVP)
 **Complexity**: High | **Effort**: Very High
 
 - **3.2.1 Azure AI Foundry Service Connection**
+  - [ ] **Define integration/functional tests for AI Foundry connectivity** (e.g., test API route, backend connection, error handling)
   - [ ] Verify `lib/aiClient.ts` connectivity to Azure AI Foundry within the agent flow.
   - [ ] Create necessary API routes in Next.js to handle requests from the agent UI to the backend AI logic.
+  - [ ] **Validate by running the defined tests and confirming all pass**
 
 - **3.2.2 Step 1: Design Concept Generation (LLM)**
+  - [ ] **Define integration/functional tests for design concept generation** (e.g., test API input/output, state update, UI display)
   - [ ] API route: `/api/agent/generate-design-concepts`
     - Input: Creative brief, User GUID.
   - [ ] Backend: Use `aiClient.ts` to call LLM (e.g., GPT-4o-mini) to generate 1-3 design concepts (text/JSON).
   - [ ] Store generated concepts in client-side state.
   - [ ] Display concepts in the sequential UI.
+  - [ ] **Validate by running the defined tests and confirming all pass**
 
 - **3.2.3 Step 2: Design Evaluation (LLM)**
+  - [ ] **Define integration/functional tests for design evaluation** (e.g., test scoring/ranking, state update, UI display)
   - [ ] API route: `/api/agent/evaluate-designs`
     - Input: Generated design concepts, User GUID.
   - [ ] Backend: Use `aiClient.ts` to call LLM to score and rank concepts.
   - [ ] Store evaluation results in client-side state.
   - [ ] Display scores/ranking in the UI.
+  - [ ] **Validate by running the defined tests and confirming all pass**
 
 - **3.2.4 Step 3: Figma Spec Generation (LLM - Simplified MVP)**
+  - [ ] **Define integration/functional tests for Figma spec generation** (e.g., test API input/output, state update, UI display)
   - [ ] API route: `/api/agent/generate-figma-spec`
     - Input: Selected design concept, User GUID.
   - [ ] Backend: Use `aiClient.ts` to call LLM to generate a simplified Figma-compatible spec (JSON).
     *(Focus on structure, not pixel-perfect visual fidelity for MVP)*
   - [ ] Store generated spec in client-side state.
   - [ ] Display confirmation or a simple view of the spec structure in UI.
+  - [ ] **Validate by running the defined tests and confirming all pass**
 
 - **3.2.5 Step 4: Spec Selection (LLM or User Choice for MVP)**
+  - [ ] **Define integration/functional tests for spec selection** (e.g., test selection logic, state update, UI confirmation)
   - [ ] If multiple specs were generated (unlikely for MVP's simplified Figma step), allow user to select or have LLM select.
   - [ ] For MVP with single spec: Display the generated spec for user confirmation.
   - [ ] Store selected/confirmed spec in client-side state.
+  - [ ] **Validate by running the defined tests and confirming all pass**
 
 - **3.2.6 Step 5: Code Generation (LLM - Simplified MVP)**
+  - [ ] **Define integration/functional tests for code generation** (e.g., test API input/output, state update, code display)
   - [ ] API route: `/api/agent/generate-code`
     - Input: Selected Figma spec (JSON), User GUID.
   - [ ] Backend: Use `aiClient.ts` to call LLM to generate a basic Next.js + TypeScript feature/component.
     *(Focus on a single, simple component based on the spec for MVP)*
   - [ ] Store generated code (string/file content) in client-side state.
   - [ ] Display a snippet or confirmation of the generated code in UI.
+  - [ ] **Validate by running the defined tests and confirming all pass**
 
 - **3.2.7 Step 6: Code Selection & Testing (LLM Review - Simplified MVP)**
+  - [ ] **Define integration/functional tests for code selection and review** (e.g., test review logic, state update, UI confirmation)
   - [ ] If multiple code versions (unlikely for MVP), allow user or LLM to select.
   - [ ] For MVP with single code output: Use LLM for a very basic review (e.g., "does this code seem to match the spec? any obvious errors?"). This is a lightweight check, not full testing.
   - [ ] Store selected/reviewed code in client-side state.
+  - [ ] **Validate by running the defined tests and confirming all pass**
 
 - **3.2.8 Step 7: Blob Storage Integration & Final Download**
+  - [ ] **Define integration/functional tests for blob storage and artifact download** (e.g., test storage API, ZIP packaging, download, retrieval)
   - [ ] API route: `/api/agent/store-execution`
     - Input: All artifacts (brief, concepts, spec, code), execution trace, User GUID, Execution ID.
   - [ ] Backend:
@@ -374,6 +395,7 @@
   - [ ] API route: `/api/agent/get-execution-details` (Basic for now)
     - Input: User GUID, Execution ID
     - Backend: Retrieve all files for a specific execution from Blob Storage.
+  - [ ] **Validate by running the defined tests and confirming all pass**
 
 ### 3.3 UI Polish & Advanced Features (Post-MVP)
 **Status**: Deferred | **Target**: Enhance UX and agent capabilities after MVP

--- a/project-management.mdc
+++ b/project-management.mdc
@@ -275,10 +275,10 @@
 **Complexity**: Medium | **Effort**: High
 
 - **3.1.1 Basic Agent Flow UI (Sequential)**
-  - [ ] Create main Next.js page/route for the AI Agent experience (e.g., `/agent`).
-  - [ ] Develop layout for multi-step agent process.
-  - [ ] Implement UI component for user to input "Creative Brief".
-  - [ ] Build sequential display for agent steps:
+  - [x] Create main Next.js page/route for the AI Agent experience (e.g., `/agent`).
+  - [x] Develop layout for multi-step agent process.
+  - [x] Implement UI component for user to input "Creative Brief".
+  - [x] Build sequential display for agent steps:
     - Design Concept Generation
     - Design Evaluation
     - Figma Spec Generation (single, MVP)
@@ -286,9 +286,9 @@
     - Code Generation (single, MVP)
     - Code Selection / Confirmation
     - Download Artifacts
-  - [ ] Implement basic visual indicators for active/completed steps (e.g., text status, simple highlighting).
-  - [ ] Add a global "Abort" button to stop the current agent flow.
-  - [ ] Basic client-side state management for the agent flow (e.g., React Context or Zustand/Jotai).
+  - [x] Implement basic visual indicators for active/completed steps (e.g., text status, simple highlighting).
+  - [x] Add a global "Abort" button to stop the current agent flow.
+  - [x] Basic client-side state management for the agent flow (e.g., React Context or Zustand/Jotai).
 
 - **3.1.2 User Identity Management (Client-Side GUID)**
   - [ ] Generate a unique GUID on the client-side for the user (if one doesn't exist in local storage).
@@ -404,10 +404,12 @@
 - **Phase 2: Foundation Setup COMPLETE** - Project structure, SP setup, and Azure service preparation documentation finalized.
   - Service Principal for Online Compiler configured.
   - PRD-aligned folder structure and TS configs implemented.
-  - `infrastructure.md` guide for Azure resources is complete and verified.
+- `infrastructure.md` guide for Azure resources is complete and verified.
+
+- **3.1.1 Basic Agent Flow UI (Sequential) COMPLETE** - Basic sequential UI with abort control and context state.
 
 ### 🎯 Next When Time Allows (Current Focus: Phase 3 MVP)
-1.  **3.1.1 Basic Agent Flow UI (Sequential)** - Build the foundational UI for the agent.
+1.  ~~**3.1.1 Basic Agent Flow UI (Sequential)** - Build the foundational UI for the agent.~~ ✅ Completed
 2.  **3.1.2 User Identity Management (Client-Side GUID)** - Implement user identification.
 3.  **3.2.1 Azure AI Foundry Service Connection** - Ensure backend can talk to AI.
 4.  **3.2.2 Step 1: Design Concept Generation (LLM)** - First AI step.

--- a/providers/AgentFlowProvider.tsx
+++ b/providers/AgentFlowProvider.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { createContext, useContext, useState } from 'react';
+
+export const agentSteps = [
+  'Design Concept Generation',
+  'Design Evaluation',
+  'Figma Spec Generation',
+  'Spec Selection / Confirmation',
+  'Code Generation',
+  'Code Selection / Confirmation',
+  'Download Artifacts'
+];
+
+interface AgentFlowContextValue {
+  steps: string[];
+  currentStep: number;
+  completed: Set<number>;
+  setCurrentStep: (i: number) => void;
+  completeStep: (i: number) => void;
+  abort: () => void;
+  aborted: boolean;
+}
+
+const AgentFlowContext = createContext<AgentFlowContextValue | undefined>(undefined);
+
+export function AgentFlowProvider({ children }: { children: React.ReactNode }) {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [completed, setCompleted] = useState<Set<number>>(new Set());
+  const [aborted, setAborted] = useState(false);
+
+  const completeStep = (i: number) => {
+    setCompleted(prev => new Set(prev).add(i));
+    setCurrentStep(i + 1);
+  };
+
+  const abort = () => {
+    setAborted(true);
+  };
+
+  return (
+    <AgentFlowContext.Provider value={{ steps: agentSteps, currentStep, completed, setCurrentStep, completeStep, abort, aborted }}>
+      {children}
+    </AgentFlowContext.Provider>
+  );
+}
+
+export function useAgentFlow() {
+  const ctx = useContext(AgentFlowContext);
+  if (!ctx) throw new Error('AgentFlowProvider missing');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- build `/agent` page
- implement agent flow component with simple state handling
- add AgentFlowProvider context
- update project management doc for 3.1.1 completion

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68478b2cab548333b2e0c85ec66ae4cf