### PR TITLE
3.2.4b enhance agent UX

### DIFF
--- a/lib/designConcept.ts
+++ b/lib/designConcept.ts
@@ -1,7 +1,8 @@
 import { generateChatCompletion } from './aiClient';
 
 export async function generateDesignConcepts(brief: string): Promise<string[]> {
-  const systemPrompt = 'You are a UI design assistant. Return an array of short design concepts as JSON.';
+  const systemPrompt =
+    'You are a UI design assistant. Return three to five short design concepts as a JSON array of strings. Each concept should be a concise, one sentence idea.';
   const response = await generateChatCompletion([
     { role: 'system', content: systemPrompt },
     { role: 'user', content: brief }


### PR DESCRIPTION
## Summary
- improve design concept prompt for multiple ideas
- add error and failure state tracking in AgentFlowProvider
- display errors and red step indicators in AgentFlow UI
- stop auto progression on failure

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ca5b665948333b448578de92e5240