### PR TITLE
3.3.6 update docs with baseline test group

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ For more detailed information, please refer to the following documents:
     - `tests/endpoints/`: External API and endpoint tests
     - `tests/ui/`: UI component tests for the agent flow and interfaces
     - `tests/e2e/`: End-to-end integration tests
-  - **Test Commands:** `npm run test:all` runs the full suite. Individual groups: `npm run test:dao`, `npm run test:services`, `npm run test:endpoints`, `npm run test:ui`, and `npm run test:e2e`.
+  - **Test Commands:** `npm run test:all` runs the full suite. Individual groups: `npm run test:baseline`, `npm run test:dao`, `npm run test:services`, `npm run test:endpoints`, `npm run test:ui`, and `npm run test:e2e`.
 - **Development Logs & Notes** (primarily for historical context)
   - [Session Logs](./docs/ai-log/): Contains logs from various development sessions.
   - [SSR Integration Notes](./docs/session-1-4b-ssr-integration.md)

--- a/prd.md
+++ b/prd.md
@@ -379,7 +379,7 @@ npx create-next-app@latest
 * **Clean Interfaces:** Each module exposes a well-defined interface
 * **Testability:** Separation facilitates unit testing of each layer
 * **Maintainability:** Makes the codebase easier to understand, extend and refactor
-* **Organized Test Suites:** Tests are grouped under `tests/dao`, `tests/services`, `tests/endpoints`, `tests/ui`, and `tests/e2e` with runner scripts. Execute all with `npm run test:all`.
+* **Organized Test Suites:** Tests are grouped under `tests/baseline`, `tests/dao`, `tests/services`, `tests/endpoints`, `tests/ui`, and `tests/e2e` with runner scripts. Execute all with `npm run test:all`.
 
 #### **File Organization:**
 

--- a/release-1.0.mdc
+++ b/release-1.0.mdc
@@ -407,7 +407,7 @@
 **Complexity**: Medium | **Effort**: Medium
 **Story**: As a developer, I need the tests organized by layer with simple runners so I can execute them quickly and reliably.
 
- - [x] Categorized tests into dao, services, endpoints, ui, and e2e folders
+ - [x] Categorized tests into baseline, dao, services, endpoints, ui, and e2e folders
 - [x] Created runner scripts for each category and a master `test:all` script
 - [x] Updated baseline scripts and documentation
 - [x] Validated by running `npm run lint` and `npm run build`


### PR DESCRIPTION
## Summary
- document baseline test group in README, PRD and release notes
- mention `npm run test:baseline` in README test commands

## Testing
- `node tests/baseline/azure-auth-test.js`
- `npm run lint`
- `npm run build`
- `npm run test:all` *(fails: Command failed: node tests/e2e/spec-selection-e2e.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684cf08adb208333a52e8d052eccef85