### PR TITLE
3.2.4b accordion fix

### DIFF
--- a/features/ai/components/AgentFlow.tsx
+++ b/features/ai/components/AgentFlow.tsx
@@ -28,14 +28,10 @@ export default function AgentFlow() {
   const userGuid = useUserGuid();
   const [brief, setBrief] = useState('');
   const [showTimeline, setShowTimeline] = useState(false);
-  const [openSteps, setOpenSteps] = useState<Set<number>>(new Set());
+  const [openStep, setOpenStep] = useState<number | null>(null);
 
   const toggleStep = (i: number) => {
-    setOpenSteps(prev => {
-      const next = new Set(prev);
-      if (next.has(i)) next.delete(i); else next.add(i);
-      return next;
-    });
+    setOpenStep(prev => (prev === i ? null : i));
   };
 
   return (
@@ -71,22 +67,22 @@ export default function AgentFlow() {
             failedStep={failedStep}
             aborted={aborted}
             onStepClick={toggleStep}
-            openSteps={openSteps}
+            openStep={openStep}
             validatedSteps={validatedSteps}
             invalidatedSteps={invalidatedSteps}
           />
-          {Array.from(openSteps).sort().map(i => (
-            <div key={i} className="mt-4 animate-fadeIn">
+          {openStep !== null && (
+            <div className="mt-4 animate-fadeIn">
               <StepResultPanel
-                stepIndex={i}
+                stepIndex={openStep}
                 brief={brief}
                 designConcepts={designConcepts}
                 evaluationResults={evaluationResults}
                 selectedConcept={selectedConcept}
-                onClose={() => toggleStep(i)}
+                onClose={() => toggleStep(openStep)}
               />
             </div>
-          ))}
+          )}
         </div>
         <ErrorHandler errors={errors} />
         <ProgressIndicator aborted={aborted} currentStep={currentStep} stepsLength={steps.length} executionTrace={executionTrace} />

--- a/features/ai/components/flow/AgentFlowTimeline.tsx
+++ b/features/ai/components/flow/AgentFlowTimeline.tsx
@@ -8,7 +8,7 @@ interface AgentFlowTimelineProps {
   failedStep: number | null;
   aborted: boolean;
   onStepClick?: (i: number) => void;
-  openSteps?: Set<number>;
+  openStep?: number | null;
   validatedSteps?: Set<number>;
   invalidatedSteps?: Set<number>;
 }
@@ -99,7 +99,7 @@ export default function AgentFlowTimeline({
   failedStep, 
   aborted, 
   onStepClick, 
-  openSteps, 
+  openStep,
   validatedSteps, 
   invalidatedSteps 
 }: AgentFlowTimelineProps) {
@@ -131,7 +131,7 @@ export default function AgentFlowTimeline({
                       ? 'bg-emerald-50 border-emerald-200 hover:shadow-md' 
                       : 'bg-gray-50 border-gray-200'
               } ${completed.has(index) ? 'cursor-pointer' : ''} ${
-                openSteps?.has(index) ? 'ring-2 ring-blue-300' : ''
+                openStep === index ? 'ring-2 ring-blue-300' : ''
               }`}
             >
               <div className="flex items-center justify-between">
@@ -150,7 +150,7 @@ export default function AgentFlowTimeline({
                 </h3>
                 {completed.has(index) && (
                   <span className="flex items-center text-sm text-blue-600">
-                    {openSteps?.has(index) ? (
+                    {openStep === index ? (
                       <>
                         <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />


### PR DESCRIPTION
## Summary
- adjust open step logic so only one step expands at a time
- update timeline to use single `openStep` state

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:all` *(fails: Command failed running spec-selection-e2e.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684f3699a6288333a41f2d53b0c143bc