### PR TITLE
docs: switch focus to release 1.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,12 @@ This repo contains the **TSLA AI UI Agent** built with Next.js 15.1.8. All contr
 
 ## Current Release Focus
 
-**🎯 Current Release: 1.0 (MVP)**
-- **Primary Document**: [PRD-1.0.md](prd-1.0.md) - MVP product requirements 
-- **Task Management**: [Release-1.0.mdc](release-1.0.mdc) - MVP task breakdown and progress
-- **Scope**: Figma spec generation and download only (no code generation, no persistent storage)
+**🎯 Current Release: 1.1 (Stabilization)**
+- **Primary Document**: [PRD-1.0.md](prd-1.0.md) - Baseline requirements
+- **Task Management**: [Release-1.1.mdc](release-1.1.mdc) - Stabilization tasks and progress
+- **Scope**: Cypress testing, React state fixes, code refactoring
 
-**⛔ Do NOT work on Release 1.1+ features yet** - Focus only on completing Release 1.0 MVP.
+**⛔ Do NOT work on Release 1.2+ features yet** - Focus only on completing Release 1.1.
 
 ## Project Structure
 
@@ -17,12 +17,12 @@ This repo contains the **TSLA AI UI Agent** built with Next.js 15.1.8. All contr
 ```
 # Core Project Structure
 prd.md                   # Project overview and release roadmap
-prd-1.0.md              # Release 1.0 (MVP) detailed requirements ← CURRENT FOCUS
+prd-1.0.md              # Release 1.0 (MVP) detailed requirements
 prd-backlog.md          # Future features (not scheduled)
 
 # Release Task Management  
-release-1.0.mdc         # Release 1.0 task breakdown ← CURRENT FOCUS
-release-1.1.mdc         # Release 1.1 planning (stabilization)
+release-1.0.mdc         # Release 1.0 task breakdown (completed)
+release-1.1.mdc         # Release 1.1 task breakdown ← CURRENT FOCUS
 release-1.2.mdc         # Release 1.2 planning (session management)
 release-1.3.mdc         # Release 1.3 planning (code generation)
 release-backlog.mdc     # Future releases backlog
@@ -30,15 +30,15 @@ release-backlog.mdc     # Future releases backlog
 
 ### Development Guidelines
 **Reference Documents in Order:**
-1. **[PRD-1.0.md](prd-1.0.md)** - Understand current MVP scope and requirements
-2. **[Release-1.0.mdc](release-1.0.mdc)** - Find specific tasks and track progress
+1. **[PRD-1.0.md](prd-1.0.md)** - Understand baseline requirements
+2. **[Release-1.1.mdc](release-1.1.mdc)** - Find stabilization tasks and track progress
 3. **[AGENTS.md](AGENTS.md)** - Follow development standards (this document)
 
 **Task Assignment Protocol:**
 - I will only assign you bite-sized tasks (e.g., 3.2.3)
 - Complete only the assigned task - do NOT move to next tasks (3.2.4, 3.3.1, etc.)
 - Update the appropriate .mdc file when task is completed
-- Do NOT work on Release 1.1+ features until Release 1.0 is complete
+- Do NOT work on Release 1.2+ features until Release 1.1 is complete
 
 ## Folder Structure
 Use the structure outlined in the PRD when adding new code:

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ A Next.js application for AI-powered agent workflows with Azure integration, des
 
 This project is organized into multiple releases with focused scope:
 
-### **Release 1.0 (MVP) - Current Focus** 
+### **Release 1.0 (MVP) - Launched**
 - **Scope**: Figma spec generation and download only (no code generation, no persistent storage)
-- **Status**: Active Development
+- **Status**: ✅ Completed
 - **Documentation**: [PRD-1.0.md](prd-1.0.md) | [Release-1.0.mdc](release-1.0.mdc)
 
-### **Release 1.1 (Stabilization) - Next**
-- **Scope**: Cypress testing, React state fixes, code refactoring  
-- **Status**: Planning
+### **Release 1.1 (Stabilization) - Current Focus**
+- **Scope**: Cypress testing, React state fixes, code refactoring
+- **Status**: Active Development
 - **Documentation**: [Release-1.1.mdc](release-1.1.mdc)
 
 ### **Release 1.2 (Session Management) - Future**
@@ -210,7 +210,7 @@ For more detailed information, please refer to the following documents:
 
 ---
 
-**Current Status**: Release 1.0 (MVP) - Active Development  
-**Current Focus**: Figma spec generation pipeline with Azure AI integration  
-**Next Milestone**: Complete MVP with stable Figma generation and download capabilities
+**Current Status**: Release 1.1 (Stabilization) - Active Development
+**Current Focus**: Cypress testing and React state stabilization
+**Next Milestone**: Complete stabilization tasks with comprehensive test coverage
 

--- a/prd.md
+++ b/prd.md
@@ -482,15 +482,15 @@ The AI agent must execute a structured pipeline with clearly defined stages and 
 
 ## 📋 Current Development Status & Next Steps
 
-**Current Status**: Release 1.0 (MVP) - Active Development  
-**Next Milestone**: Complete MVP Figma generation pipeline with reliable Azure AI integration
+**Current Status**: Release 1.1 (Stabilization) - Active Development
+**Next Milestone**: Complete stabilization tasks with comprehensive testing
 
 **Immediate Priorities:**
-1. Complete Release 1.0 MVP with core Figma generation pipeline
-2. Ensure Azure AI integration works reliably across all environments  
-3. Implement comprehensive visual execution tracking with proper state management
-4. Validate download functionality with complete ZIP artifact generation
-5. Deploy and make accessible to users for initial feedback
+1. Execute Release 1.1 stabilization tasks with Cypress testing
+2. Fix React state synchronization and component updates
+3. Refactor code for maintainability and reliability
+4. Validate application performance across browsers
+5. Finalize deployment with robust test coverage
 
 **Future Development Roadmap:**
 1. **Release 1.1**: Implement comprehensive testing infrastructure and resolve React state issues

--- a/release-1.1.mdc
+++ b/release-1.1.mdc
@@ -7,7 +7,7 @@
 - **Project Name**: TSLA AI UI Agent
 - **Framework**: Next.js 15.1.8 with App Router
 - **Release**: 1.1 (Stabilization Release)
-- **Status**: Planning Phase
+- **Status**: Active Development
 - **Prerequisites**: Release 1.0 (MVP) must be complete and stable
 
 ## Release 1.1 Goals


### PR DESCRIPTION
## Summary
- set release 1.1 as the current focus in `AGENTS.md`
- mark release 1.0 as launched in `README.md`
- update development status in `prd.md`
- mark release 1.1 planning file as active development

## Testing
- `npm run lint` *(fails: Downloading Cypress)*
- `npm run build` *(fails: Cannot find module '../server/require-hook')*

------
https://chatgpt.com/codex/tasks/task_e_687571dd21dc8333ae09d61a573049dd